### PR TITLE
Change to the Contour ingress.class annotation

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -161,7 +161,7 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 					ParentKey:     ing.Name,
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": class,
+					"projectcontour.io/ingress.class": class,
 				},
 				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing)},
 			},
@@ -190,7 +190,7 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 				// Ideally these would just be marked ClusterLocal :(
 				if strings.HasSuffix(originalHost, network.GetClusterDomainName()) {
 					privateClass := config.FromContext(ctx).Contour.VisibilityClasses[v1alpha1.IngressVisibilityClusterLocal]
-					hostProxy.Annotations["kubernetes.io/ingress.class"] = privateClass
+					hostProxy.Annotations["projectcontour.io/ingress.class"] = privateClass
 				}
 
 				proxies = append(proxies, hostProxy)

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -101,7 +101,7 @@ func TestMakeProxies(t *testing.T) {
 					ParentKey:     "bar",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": publicClass,
+					"projectcontour.io/ingress.class": publicClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -192,7 +192,7 @@ func TestMakeProxies(t *testing.T) {
 					ParentKey:     "bar",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": privateClass,
+					"projectcontour.io/ingress.class": privateClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -233,7 +233,7 @@ func TestMakeProxies(t *testing.T) {
 					ParentKey:     "bar",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": privateClass,
+					"projectcontour.io/ingress.class": privateClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -274,7 +274,7 @@ func TestMakeProxies(t *testing.T) {
 					ParentKey:     "bar",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": privateClass,
+					"projectcontour.io/ingress.class": privateClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -346,7 +346,7 @@ func TestMakeProxies(t *testing.T) {
 					ParentKey:     "bar",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": privateClass,
+					"projectcontour.io/ingress.class": privateClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -430,7 +430,7 @@ func TestMakeProxies(t *testing.T) {
 					ParentKey:     "bar",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": publicClass,
+					"projectcontour.io/ingress.class": publicClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -538,7 +538,7 @@ func TestMakeProxies(t *testing.T) {
 					ParentKey:     "bar",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": publicClass,
+					"projectcontour.io/ingress.class": publicClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -648,7 +648,7 @@ func TestMakeProxies(t *testing.T) {
 					ParentKey:     "bar",
 				},
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": publicClass,
+					"projectcontour.io/ingress.class": publicClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",


### PR DESCRIPTION
The prior annotation is generally used in concert with K8s Ingress resources, and currently emits a warning from Contour.  This was guidance from the Contour folks, and avoids some warning logs in Contour.

Fixes: https://github.com/mattmoor/net-contour/issues/4